### PR TITLE
Fix function redeclaration

### DIFF
--- a/inc/i18n.php
+++ b/inc/i18n.php
@@ -10,6 +10,11 @@
 
 namespace Inpsyde\Validator;
 
+// Exit early in case multiple Composer autoloaders try to include this file.
+if ( function_exists( __NAMESPACE__ . '\\' . 'load_translations' ) ) {
+	return;
+}
+
 /**
  * @param string $path
  *


### PR DESCRIPTION
Return early if the `load_translations()` function has already been declared.

Resolves #5