### PR TITLE
removed the options property from validators.

### DIFF
--- a/src/Between.php
+++ b/src/Between.php
@@ -37,11 +37,6 @@ class Between implements ExtendedValidatorInterface {
 
 	/**
 	 * @var array
-	 */
-	protected $options = [ ];
-
-	/**
-	 * @var array
 	 * @deprecated
 	 */
 	protected $message_templates = [
@@ -52,14 +47,14 @@ class Between implements ExtendedValidatorInterface {
 	public function __construct( array $options = [ ] ) {
 
 		// Whether to do inclusive comparisons, allowing equivalence to min and/or max
-		$this->options[ 'inclusive' ] = isset( $options[ 'inclusive' ] )
+		$options[ 'inclusive' ] = isset( $options[ 'inclusive' ] )
 			? filter_var( $options[ 'inclusive' ], FILTER_VALIDATE_BOOLEAN )
 			: TRUE;
 
-		$this->options[ 'min' ] = isset( $options[ 'min' ] ) ? $options[ 'min' ] : 0;
-		$this->options[ 'max' ] = isset( $options[ 'max' ] ) ? $options[ 'max' ] : PHP_INT_MAX;
+		$options[ 'min' ] = isset( $options[ 'min' ] ) ? $options[ 'min' ] : 0;
+		$options[ 'max' ] = isset( $options[ 'max' ] ) ? $options[ 'max' ] : PHP_INT_MAX;
 
-		$this->input_data            = $this->options;
+		$this->input_data            = $options;
 		$this->input_data[ 'value' ] = NULL;
 	}
 
@@ -69,9 +64,9 @@ class Between implements ExtendedValidatorInterface {
 	public function is_valid( $value ) {
 
 		$this->input_data[ 'value' ] = $value;
-		$inc                         = $this->options[ 'inclusive' ];
-		$ok                          = $inc ? $value >= $this->options[ 'min' ] : $value > $this->options[ 'min' ];
-		$ok and $ok = $inc ? $value <= $this->options[ 'max' ] : $value < $this->options[ 'max' ];
+		$inc                         = $this->input_data[ 'inclusive' ];
+		$ok                          = $inc ? $value >= $this->input_data[ 'min' ] : $value > $this->input_data[ 'min' ];
+		$ok and $ok = $inc ? $value <= $this->input_data[ 'max' ] : $value < $this->input_data[ 'max' ];
 		$ok or $this->error_code = $inc ? ErrorLoggerInterface::NOT_BETWEEN : ErrorLoggerInterface::NOT_BETWEEN_STRICT;
 		$ok or $this->update_error_messages();
 

--- a/src/Callback.php
+++ b/src/Callback.php
@@ -25,11 +25,6 @@ class Callback implements ExtendedValidatorInterface {
 	use GetErrorMessagesTrait;
 
 	/**
-	 * @var array
-	 */
-	protected $options = [ ];
-
-	/**
 	 * @param callable $callback
 	 *
 	 * @return Callback
@@ -48,12 +43,11 @@ class Callback implements ExtendedValidatorInterface {
 			throw new \InvalidArgumentException( sprintf( '%s "callback" option must be callable.', __CLASS__ ) );
 		}
 
-		$this->options[ 'callback' ]   = $options[ 'callback' ];
-		$this->options[ 'error_code' ] = empty( $options[ 'error_code' ] ) || ! is_string( $options[ 'error_code' ] )
+		$options[ 'error_code' ] = empty( $options[ 'error_code' ] ) || ! is_string( $options[ 'error_code' ] )
 			? ErrorLoggerInterface::CUSTOM_ERROR
 			: $options[ 'error_code' ];
 
-		$this->input_data            = $this->options;
+		$this->input_data            = $options;
 		$this->input_data[ 'value' ] = NULL;
 	}
 
@@ -62,15 +56,15 @@ class Callback implements ExtendedValidatorInterface {
 	 */
 	public function is_valid( $value ) {
 
-		$this->input_data = [ 'value' => $value ];
+		$this->input_data[ 'value' ] = $value;
 
 		/** @var callable $callback */
-		$callback = $this->options[ 'callback' ];
+		$callback = $this->input_data[ 'callback' ];
 
 		$valid = filter_var( $callback( $value ), FILTER_VALIDATE_BOOLEAN );
 
 		if ( ! $valid ) {
-			$this->error_code = $this->options[ 'error_code' ];
+			$this->error_code = $this->input_data[ 'error_code' ];
 			$this->update_error_messages();
 		}
 

--- a/src/ClassName.php
+++ b/src/ClassName.php
@@ -23,20 +23,15 @@ class ClassName implements ExtendedValidatorInterface {
 	use GetErrorMessagesTrait;
 
 	/**
-	 * @var array
-	 */
-	protected $options = [ ];
-
-	/**
 	 * @param array $options
 	 */
 	public function __construct( array $options = [ ] ) {
 
-		$this->options[ 'autoload' ] = array_key_exists( 'autoload', $options )
+		$options[ 'autoload' ] = array_key_exists( 'autoload', $options )
 			? filter_var( $options[ 'autoload' ], FILTER_VALIDATE_BOOLEAN )
 			: TRUE;
 
-		$this->input_data            = $this->options;
+		$this->input_data            = $options;
 		$this->input_data[ 'value' ] = NULL;
 	}
 
@@ -54,7 +49,7 @@ class ClassName implements ExtendedValidatorInterface {
 			return FALSE;
 		}
 
-		if ( class_exists( $value, $this->options[ 'autoload' ] ) ) {
+		if ( class_exists( $value, $this->input_data[ 'autoload' ] ) ) {
 			return TRUE;
 		}
 

--- a/src/Date.php
+++ b/src/Date.php
@@ -40,11 +40,6 @@ class Date implements ExtendedValidatorInterface {
 
 	/**
 	 * @var array
-	 */
-	protected $options = [ ];
-
-	/**
-	 * @var array
 	 * @deprecated
 	 */
 	protected $message_templates = [
@@ -58,11 +53,11 @@ class Date implements ExtendedValidatorInterface {
 	 */
 	public function __construct( array $options = [ ] ) {
 
-		$this->options[ 'format' ] = isset( $options[ 'format' ] ) && is_string( $options[ 'format' ] )
+		$options[ 'format' ] = isset( $options[ 'format' ] ) && is_string( $options[ 'format' ] )
 			? $options[ 'format' ]
 			: 'd.m.Y';
 
-		$this->input_data            = $this->options;
+		$this->input_data            = $options;
 		$this->input_data[ 'value' ] = NULL;
 
 	}
@@ -146,7 +141,7 @@ class Date implements ExtendedValidatorInterface {
 	 */
 	protected function convert_string( $value ) {
 
-		$format = $this->options[ 'format' ];
+		$format = $this->input_data[ 'format' ];
 		$date   = \DateTime::createFromFormat( $format, $value );
 
 		// Invalid dates can show up as warnings (ie. "2007-02-99") and still return a DateTime object.

--- a/src/Email.php
+++ b/src/Email.php
@@ -27,11 +27,11 @@ class Email implements ExtendedValidatorInterface {
 	 */
 	public function __construct( array $options = [ ] ) {
 
-		$this->options[ 'check_dns' ] = isset( $options[ 'check_dns' ] )
+		$options[ 'check_dns' ] = isset( $options[ 'check_dns' ] )
 			? filter_var( $options[ 'check_dns' ], FILTER_VALIDATE_BOOLEAN )
 			: FALSE;
 
-		$this->input_data            = $this->options;
+		$this->input_data            = $options;
 		$this->input_data[ 'value' ] = NULL;
 	}
 
@@ -66,7 +66,7 @@ class Email implements ExtendedValidatorInterface {
 			return FALSE;
 		}
 
-		if ( ! $this->options[ 'check_dns' ] ) {
+		if ( ! $this->input_data[ 'check_dns' ] ) {
 			return TRUE;
 		}
 

--- a/src/GreaterThan.php
+++ b/src/GreaterThan.php
@@ -35,11 +35,6 @@ class GreaterThan implements ExtendedValidatorInterface {
 
 	/**
 	 * @var array
-	 */
-	protected $options = [ ];
-
-	/**
-	 * @var array
 	 * @deprecated
 	 */
 	protected $message_templates = [
@@ -53,12 +48,12 @@ class GreaterThan implements ExtendedValidatorInterface {
 	public function __construct( array $options = [ ] ) {
 
 		// Whether to do inclusive comparisons, allowing equivalence to min and/or max
-		$this->options[ 'inclusive' ] = isset( $options[ 'inclusive' ] )
+		$options[ 'inclusive' ] = isset( $options[ 'inclusive' ] )
 			? filter_var( $options[ 'inclusive' ], FILTER_VALIDATE_BOOLEAN )
 			: FALSE;
 
-		$this->options[ 'min' ]      = isset( $options[ 'min' ] ) ? $options[ 'min' ] : 0;
-		$this->input_data            = $this->options;
+		$options[ 'min' ]            = isset( $options[ 'min' ] ) ? $options[ 'min' ] : 0;
+		$this->input_data            = $options;
 		$this->input_data[ 'value' ] = NULL;
 	}
 
@@ -69,8 +64,8 @@ class GreaterThan implements ExtendedValidatorInterface {
 
 		$this->input_data[ 'value' ] = $value;
 
-		$inc   = $this->options[ 'inclusive' ];
-		$valid = $inc ? $value >= $this->options[ 'min' ] : $value > $this->options[ 'min' ];
+		$inc   = $this->input_data[ 'inclusive' ];
+		$valid = $inc ? $value >= $this->input_data[ 'min' ] : $value > $this->input_data[ 'min' ];
 		$valid or $this->error_code = $inc
 			? Error\ErrorLoggerInterface::NOT_GREATER_INCLUSIVE
 			: Error\ErrorLoggerInterface::NOT_GREATER;

--- a/src/InArray.php
+++ b/src/InArray.php
@@ -30,11 +30,6 @@ class InArray implements ExtendedValidatorInterface {
 
 	/**
 	 * @var array
-	 */
-	protected $options = [ ];
-
-	/**
-	 * @var array
 	 * @deprecated
 	 */
 	protected $message_templates = [
@@ -47,15 +42,15 @@ class InArray implements ExtendedValidatorInterface {
 	public function __construct( array $options = [ ] ) {
 
 		// Whether to do inclusive comparisons, allowing equivalence to min and/or max
-		$this->options[ 'strict' ] = isset( $options[ 'strict' ] )
+		$options[ 'strict' ] = isset( $options[ 'strict' ] )
 			? filter_var( $options[ 'strict' ], FILTER_VALIDATE_BOOLEAN )
 			: TRUE;
 
-		$this->options[ 'haystack' ] = isset( $options[ 'haystack' ] )
+		$options[ 'haystack' ] = isset( $options[ 'haystack' ] )
 			? (array) $options[ 'haystack' ]
 			: [ ];
 
-		$this->input_data            = $this->options;
+		$this->input_data            = $options;
 		$this->input_data[ 'value' ] = NULL;
 	}
 
@@ -66,7 +61,7 @@ class InArray implements ExtendedValidatorInterface {
 
 		$this->input_data[ 'value' ] = $value;
 
-		$valid = in_array( $value, $this->options[ 'haystack' ], $this->options[ 'strict' ] );
+		$valid = in_array( $value, $this->input_data[ 'haystack' ], $this->input_data[ 'strict' ] );
 		$valid or $this->error_code = Error\ErrorLoggerInterface::NOT_IN_ARRAY;
 		$valid or $this->update_error_messages();
 

--- a/src/LessThan.php
+++ b/src/LessThan.php
@@ -43,22 +43,17 @@ class LessThan implements ExtendedValidatorInterface {
 	];
 
 	/**
-	 * @var array
-	 */
-	protected $options = [ ];
-
-	/**
 	 * @param array $options
 	 */
 	public function __construct( array $options = [ ] ) {
 
 		// Whether to do inclusive comparisons, allowing equivalence to min and/or max
-		$this->options[ 'inclusive' ] = isset( $options[ 'inclusive' ] )
+		$options[ 'inclusive' ] = isset( $options[ 'inclusive' ] )
 			? filter_var( $options[ 'inclusive' ], FILTER_VALIDATE_BOOLEAN )
 			: FALSE;
 
-		$this->options[ 'max' ]      = isset( $options[ 'max' ] ) ? $options[ 'max' ] : 0;
-		$this->input_data            = $this->options;
+		$options[ 'max' ]      = isset( $options[ 'max' ] ) ? $options[ 'max' ] : 0;
+		$this->input_data            = $options;
 		$this->input_data[ 'value' ] = NULL;
 	}
 
@@ -69,8 +64,8 @@ class LessThan implements ExtendedValidatorInterface {
 
 		$this->input_data[ 'value' ] = $value;
 
-		$inc   = $this->options[ 'inclusive' ];
-		$valid = $inc ? $value <= $this->options[ 'max' ] : $value < $this->options[ 'max' ];
+		$inc   = $this->input_data[ 'inclusive' ];
+		$valid = $inc ? $value <= $this->input_data[ 'max' ] : $value < $this->input_data[ 'max' ];
 		$valid or $this->error_code = $inc
 			? Error\ErrorLoggerInterface::NOT_LESS_INCLUSIVE
 			: Error\ErrorLoggerInterface::NOT_LESS;

--- a/src/Negate.php
+++ b/src/Negate.php
@@ -25,11 +25,6 @@ class Negate implements SecondaryValidatorInterface {
 	use GetErrorMessagesTrait;
 
 	/**
-	 * @var array
-	 */
-	protected $options = [ ];
-
-	/**
 	 * @inheritdoc
 	 * @return Negate
 	 */
@@ -63,8 +58,8 @@ class Negate implements SecondaryValidatorInterface {
 			);
 		}
 
-		$this->options[ 'validator' ]         = $validator;
-		$this->input_data                     = $this->options;
+		$this->input_data                     = $options;
+		$this->input_data[ 'validator' ]      = $validator;
 		$class_parts                          = explode( '\\', get_class( $validator ) );
 		$this->input_data[ 'validator_name' ] = end( $class_parts );
 		$this->input_data[ 'value' ]          = NULL;
@@ -78,7 +73,7 @@ class Negate implements SecondaryValidatorInterface {
 		$this->input_data[ 'value' ] = $value;
 
 		/** @var ExtendedValidatorInterface $validator */
-		$validator = $this->options[ 'validator' ];
+		$validator = $this->input_data[ 'validator' ];
 		$valid     = $validator->is_valid( $value );
 
 		if ( $valid ) {

--- a/src/RegEx.php
+++ b/src/RegEx.php
@@ -40,11 +40,6 @@ class RegEx implements ExtendedValidatorInterface {
 
 	/**
 	 * @var array
-	 */
-	protected $options = [ ];
-
-	/**
-	 * @var array
 	 * @deprecated
 	 */
 	protected $message_templates = [
@@ -63,8 +58,8 @@ class RegEx implements ExtendedValidatorInterface {
 		$last    = $pattern ? substr( $pattern, - 1, 1 ) : '';
 		( $first && ( $first !== $last || strlen( $pattern ) === 1 ) ) and $pattern = "~{$pattern}~";
 
-		$this->options[ 'pattern' ]  = $pattern;
-		$this->input_data            = $this->options;
+		$options[ 'pattern' ]        = $pattern;
+		$this->input_data            = $options;
 		$this->input_data[ 'value' ] = NULL;
 	}
 
@@ -75,7 +70,7 @@ class RegEx implements ExtendedValidatorInterface {
 
 		$this->input_data[ 'value' ] = $value;
 
-		$pattern = $this->options[ 'pattern' ];
+		$pattern = $this->input_data[ 'pattern' ];
 
 		if ( ! is_string( $value ) && ! is_int( $value ) && ! is_float( $value ) ) {
 			$this->error_code = Error\ErrorLoggerInterface::INVALID_TYPE_NON_SCALAR;

--- a/src/Size.php
+++ b/src/Size.php
@@ -23,11 +23,6 @@ class Size implements ExtendedValidatorInterface {
 	use GetErrorMessagesTrait;
 
 	/**
-	 * @var array
-	 */
-	protected $options = [ ];
-
-	/**
 	 * @param array $options
 	 */
 	public function __construct( array $options = [ ] ) {
@@ -41,8 +36,9 @@ class Size implements ExtendedValidatorInterface {
 			);
 		}
 
-		$this->options[ 'size' ]     = $size;
-		$this->input_data            = $this->options;
+		$options[ 'size' ] = $size;
+
+		$this->input_data            = $options;
 		$this->input_data[ 'value' ] = NULL;
 
 	}
@@ -52,7 +48,7 @@ class Size implements ExtendedValidatorInterface {
 	 */
 	public function is_valid( $value ) {
 
-		$this->input_data = [ 'value' => $value ];
+		$this->input_data[ 'value' ] = $value;
 
 		if (
 			is_resource( $value )
@@ -69,7 +65,7 @@ class Size implements ExtendedValidatorInterface {
 			$value      = get_object_vars( $value_copy );
 		}
 
-		if ( $this->calc_size( $value ) === $this->options[ 'size' ] ) {
+		if ( $this->calc_size( $value ) === $this->input_data[ 'size' ] ) {
 			return TRUE;
 		}
 

--- a/src/Type.php
+++ b/src/Type.php
@@ -28,7 +28,6 @@ class Type implements ExtendedValidatorInterface {
 		'double'      => 'double',
 		'float'       => 'double',
 		'string'      => 'string',
-		'int'         => 'integer',
 		'boolean'     => 'boolean',
 		'bool'        => 'boolean',
 		'resource'    => 'resource',
@@ -40,11 +39,6 @@ class Type implements ExtendedValidatorInterface {
 	];
 
 	/**
-	 * @var array
-	 */
-	protected $options = [ ];
-
-	/**
 	 * @param array $options
 	 */
 	public function __construct( array $options = [ ] ) {
@@ -53,11 +47,11 @@ class Type implements ExtendedValidatorInterface {
 			throw new \InvalidArgumentException( sprintf( '%s "type" option must be in a string.', __CLASS__ ) );
 		}
 
-		$type  = $options[ 'type' ];
-		$lower = strtolower( $type );
+		$type              = $options[ 'type' ];
+		$lower             = strtolower( $type );
+		$options[ 'type' ] = array_key_exists( $lower, self::$types ) ? self::$types[ $lower ] : $type;
 
-		$this->options[ 'type' ]     = array_key_exists( $lower, self::$types ) ? self::$types[ $lower ] : $type;
-		$this->input_data            = $this->options;
+		$this->input_data            = $options;
 		$this->input_data[ 'value' ] = NULL;
 	}
 
@@ -66,21 +60,21 @@ class Type implements ExtendedValidatorInterface {
 	 */
 	public function is_valid( $value ) {
 
-		$this->input_data = [ 'value' => $value ];
+		$this->input_data[ 'value' ] = $value;
 
-		if ( strtolower( gettype( $value ) ) === $this->options[ 'type' ] ) {
+		if ( strtolower( gettype( $value ) ) === $this->input_data[ 'type' ] ) {
 			return TRUE;
 		}
 
-		if ( is_object( $value ) && is_a( $value, $this->options[ 'type' ] ) ) {
+		if ( is_object( $value ) && is_a( $value, $this->input_data[ 'type' ] ) ) {
 			return TRUE;
 		}
 
-		if ( $this->options[ 'type' ] === 'numeric' && is_numeric( $value ) ) {
+		if ( $this->input_data[ 'type' ] === 'numeric' && is_numeric( $value ) ) {
 			return TRUE;
 		}
 
-		if ( $this->options[ 'type' ] === 'traversable' && ( is_array( $value ) || $value instanceof \Traversable ) ) {
+		if ( $this->input_data[ 'type' ] === 'traversable' && ( is_array( $value ) || $value instanceof \Traversable ) ) {
 			return TRUE;
 		}
 

--- a/src/Url.php
+++ b/src/Url.php
@@ -66,14 +66,6 @@ class Url implements ExtendedValidatorInterface {
 	/**
 	 * @var array
 	 */
-	protected $options = [
-		'allowed_protocols' => [ 'http', 'https' ],
-		'check_dns'         => FALSE
-	];
-
-	/**
-	 * @var array
-	 */
 	protected $message_templates = [
 		Error\ErrorLoggerInterface::NOT_URL                 => "The input <code>%value%</code> is not a valid URL.",
 		Error\ErrorLoggerInterface::INVALID_TYPE_NON_STRING => "The input <code>%value%</code> should be a string.",
@@ -86,17 +78,15 @@ class Url implements ExtendedValidatorInterface {
 	 */
 	public function __construct( array $options = [ ] ) {
 
-		$protocols = isset( $options[ 'allowed_protocols' ] ) && is_array( $options[ 'allowed_protocols' ] )
+		$options[ 'allowed_protocols' ] = isset( $options[ 'allowed_protocols' ] ) && is_array( $options[ 'allowed_protocols' ] )
 			? array_filter( $options[ 'allowed_protocols' ], 'is_string ' )
-			: [ ];
+			: [ 'http', 'https' ];
 
-		$this->options[ 'allowed_protocols' ] = $protocols ? : [ 'http', 'https' ];
-
-		$this->options[ 'check_dns' ] = isset( $options[ 'check_dns' ] )
+		$options[ 'check_dns' ] = isset( $options[ 'check_dns' ] )
 			? filter_var( $options[ 'check_dns' ], FILTER_VALIDATE_BOOLEAN )
 			: FALSE;
 
-		$this->input_data            = $this->options;
+		$this->input_data            = $options;
 		$this->input_data[ 'value' ] = NULL;
 	}
 
@@ -124,7 +114,7 @@ class Url implements ExtendedValidatorInterface {
 			return FALSE;
 		}
 
-		$pattern = sprintf( self::PATTERN, implode( '|', $this->options[ 'allowed_protocols' ] ) );
+		$pattern = sprintf( self::PATTERN, implode( '|', $this->input_data[ 'allowed_protocols' ] ) );
 		if ( ! preg_match( $pattern, $value ) ) {
 			$this->error_code = Error\ErrorLoggerInterface::NOT_URL;
 			$this->update_error_messages();
@@ -132,7 +122,7 @@ class Url implements ExtendedValidatorInterface {
 			return FALSE;
 		}
 
-		if ( ! $this->options[ 'check_dns' ] ) {
+		if ( ! $this->input_data[ 'check_dns' ] ) {
 			return TRUE;
 		}
 

--- a/src/WpFilter.php
+++ b/src/WpFilter.php
@@ -25,11 +25,6 @@ class WpFilter implements ExtendedValidatorInterface {
 	use GetErrorMessagesTrait;
 
 	/**
-	 * @var array
-	 */
-	protected $options = [ ];
-
-	/**
 	 * @param array $options
 	 */
 	public function __construct( array $options = [ ] ) {
@@ -42,8 +37,7 @@ class WpFilter implements ExtendedValidatorInterface {
 			throw new \InvalidArgumentException( sprintf( '%s can only be used in WordPress context.', __CLASS__ ) );
 		}
 
-		$this->options[ 'filter' ]   = $options[ 'filter' ];
-		$this->input_data            = $this->options;
+		$this->input_data            = $options;
 		$this->input_data[ 'value' ] = NULL;
 	}
 
@@ -52,9 +46,9 @@ class WpFilter implements ExtendedValidatorInterface {
 	 */
 	public function is_valid( $value ) {
 
-		$this->input_data = [ 'value' => $value ];
+		$this->input_data[ 'value' ] = $value;
 
-		$valid = apply_filters( $this->options[ 'filter' ], $value );
+		$valid = apply_filters( $this->input_data[ 'filter' ], $value );
 		$valid = filter_var( $valid, FILTER_VALIDATE_BOOLEAN );
 
 		if ( ! $valid ) {


### PR DESCRIPTION
* removed the options property from validators.
* Type-Validator: removed duplicated array key from $types, fixed overwriting the $input_data in `is_valid`-method.

See #7