### PR TITLE
Fix url regex php 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,16 @@ php:
   - hhvm
   - nightly
 
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+
 sudo: false
 
 matrix:
   fast_finish: true
   allow_failures:
+    - php: 7.4
     - php: hhvm
     - php: nightly
 
@@ -22,7 +27,7 @@ before_install:
   - travis_retry composer self-update
 
 install:
-  - travis_retry composer update
+  - travis_retry composer update --prefer-dist
 
 before_script:
   - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then phpenv config-rm xdebug.ini; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
   - hhvm
   - nightly
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ before_script:
 
 script:
   - find src \( -name '*.php' \) -exec php -l {} \;
-  - phpunit
+  - vendor/bin/phpunit

--- a/src/Url.php
+++ b/src/Url.php
@@ -51,7 +51,7 @@ class Url implements ExtendedValidatorInterface {
             (%s)://                                 # protocol
             (([\pL\pN-]+:)?([\pL\pN-]+)@)?          # basic auth
             (
-                ([\pL\pN\pS-\.])+(\.?([\pL]|xn\-\-[\pL\pN-]+)+\.?) # a domain name
+                ([\pL\pN\pS\-\.])+(\.?([\pL]|xn\-\-[\pL\pN\-]+)+\.?) # a domain name
                     |                                              # or
                 \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}                 # a IP address
                     |                                              # or


### PR DESCRIPTION
Using the `Url` validator in PHP 7.3 produces the following error:
`preg_match(): Compilation failed: invalid range in character class`
Error reports for this behaviour can be found on the internet, for example [here](https://github.com/atymic/twitter/pull/252) The problem is an unescaped hyphen character in the regex pattern, which I attempted to fix in this PR

To validate that the previously breaking tests indeed pass now, I have also updated the travis config to include all modern PHP versions and added a cache directive for composer packages.

Note that travis can no longer install a php5.5 binary, so I dropped that version.